### PR TITLE
docs: Update changelog for v3.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Bulletproof Plugin Reload**: Comprehensive resource cleanup system preventing duplicate panels and exceptions during plugin reload
+
+### Fixed
+- **Plugin Reload Issues**: Fixed duplicate panel creation and AttributeError exceptions during plugin unload/reload cycles  
+- **Resource Leaks**: Enhanced signal disconnection and Qt widget lifecycle management to prevent orphaned resources
+
+### Changed
+- **Error Handling**: Improved defensive programming with triple-layer exception handling across cleanup operations
+- **Import Organization**: Moved all imports to module level for better stability during plugin shutdown
+
+---
+
+## [3.10.0] - 2025-09-01
+
+### Added
 - **Service Layer Architecture**: Centralized coordinate parsing service with singleton pattern eliminating 15+ line code duplication across UI components
 - **Try-Parse Architecture**: Exception-based parsing using mature coordinate libraries instead of error-prone regex pre-validation
 - **Comprehensive Test Infrastructure**: Unified test runner with cross-platform QGIS detection supporting standalone, service, validation, and integration tests
@@ -17,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Critical UTM Misclassification Bug**: UTM coordinates like `500000 4500000 1000` are no longer incorrectly parsed as DMS coordinates
 - **Service Layer Integration**: All UI components (coordinateConverter, digitizer, multizoom, zoomToLatLon) now use centralized parser service
 - **Python Syntax Errors**: Fixed critical indentation errors preventing code execution after refactoring
+- **Regex Pattern Bugs**: Resolved critical double backslash issues in coordinate format detection
 
 ### Changed  
 - **Fundamental Architecture Shift**: From regex pre-validation to mature library validation with exception handling


### PR DESCRIPTION
## Summary
Updates CHANGELOG.md to properly document version history and prepare for v3.11.0 release.

## Changes
- Document v3.10.0 release with service layer and try-parse architecture improvements
- Prepare v3.11.0 release section with bulletproof plugin reload improvements  
- Reorganize changelog to properly track version history
- Move completed features from [Unreleased] to appropriate version sections

## Context
This ensures the changelog accurately reflects what was released in each version, particularly documenting the significant improvements in v3.10.0 that were not properly recorded.

🤖 Generated with [Claude Code](https://claude.ai/code)