### PR TITLE
fix: Clean up Makefile production deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,20 +10,24 @@ else
     PYTHON = python
 endif
 
-PY_FILES = __init__.py captureCoordinate.py captureExtent.py coordinateConverter.py copyLatLonTool.py dialog_manager.py digitizer.py ecef.py enhanced_settings.py extent_operations.py fast_coordinate_detector.py field2geom.py geohash.py geom2field.py geom2wkt.py georef.py input_validation.py latLonFunctions.py latLonTools.py latLonToolsProcessing.py lazy_loader.py maidenhead.py mapProviders.py mgrs.py mgrstogeom.py multizoom.py olc.py parser_service.py pluscodes.py plugin_cleanup.py plugin_enhancements.py provider.py run_all_tests.py settings.py showOnMapTool.py smart_parser.py text_preservation.py tomgrs.py ups.py util.py utm.py wkt2layers.py zoomToLatLon.py
+PY_FILES = __init__.py captureCoordinate.py captureExtent.py coordinateConverter.py copyLatLonTool.py dialog_manager.py digitizer.py ecef.py enhanced_settings.py extent_operations.py fast_coordinate_detector.py field2geom.py geohash.py geom2field.py geom2wkt.py georef.py input_validation.py latLonFunctions.py latLonTools.py latLonToolsProcessing.py lazy_loader.py maidenhead.py mapProviders.py mgrs.py mgrstogeom.py multizoom.py olc.py parser_service.py pluscodes.py plugin_cleanup.py plugin_enhancements.py provider.py settings.py showOnMapTool.py smart_parser.py text_preservation.py tomgrs.py ups.py util.py utm.py wkt2layers.py zoomToLatLon.py
 EXTRAS = metadata.txt icon.png LICENSE
 
+# Deploy plugin to local QGIS installation
 deploy:
 	mkdir -p $(PLUGINS)
 	mkdir -p $(PLUGINS)/i18n
+	# Copy translation files
 	cp -vf i18n/latlonTools_fr.qm $(PLUGINS)/i18n
 	cp -vf i18n/latlonTools_zh.qm $(PLUGINS)/i18n
+	# Copy core plugin files (production code only)
 	cp -vf $(PY_FILES) $(PLUGINS)
 	cp -vf $(EXTRAS) $(PLUGINS)
+	# Copy plugin resources
 	cp -vfr images $(PLUGINS)
 	cp -vfr ui $(PLUGINS)
 	cp -vfr doc $(PLUGINS)
-	cp -vfr tests $(PLUGINS)
+	# Generate and copy HTML documentation
 	cp -vf helphead.html index.html
 	if [ -d .venv ]; then \
 		source .venv/bin/activate && $(PYTHON) -m markdown -x extra readme.md >> index.html; \
@@ -32,6 +36,10 @@ deploy:
 	fi
 	echo '</body>' >> index.html
 	cp -vf index.html $(PLUGINS)/index.html
+
+# Deploy with tests (for development/testing only)
+deploy-with-tests: deploy
+	cp -vfr tests $(PLUGINS)
 
 # Test commands
 test: 
@@ -61,4 +69,4 @@ test-clean:
 	find tests/ -name "*.pyc" -delete
 	find tests/ -name "__pycache__" -type d -exec rm -rf {} +
 
-.PHONY: test test-unit test-validation test-verbose test-flipping test-realworld test-comprehensive test-clean
+.PHONY: deploy deploy-with-tests test test-unit test-validation test-verbose test-flipping test-realworld test-comprehensive test-clean


### PR DESCRIPTION
## Summary
- Remove test runner files from production deployment
- Separate production vs development deployment workflows
- Add clear documentation for deployment targets

## Changes
- **Removed** `run_all_tests.py` from production `PY_FILES` list
- **Removed** `tests/` directory from production `deploy` target  
- **Added** `deploy-with-tests` target for development use
- **Added** clear comments explaining deployment strategy

## Benefits
- **Clean production deployments**: QGIS plugin installations only contain necessary files
- **Maintained development workflow**: `deploy-with-tests` target preserves testing capability
- **Improved documentation**: Clear separation of production vs development deployment

## Testing
- ✅ Verified production deployment excludes test files
- ✅ Confirmed `deploy-with-tests` target includes test files for development

🤖 Generated with [Claude Code](https://claude.ai/code)