### PR TITLE
Fix projected CRS zoom regression and address Copilot review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,19 @@ and this project adheres to
 
 ### Fixed
 
--
+- **Projected CRS Zoom**: Restored Project CRS and Custom CRS coordinate parsing
+  in the Zoom dialog. These modes were broken in v3.14.2 when the ultra-fast
+  path was unconditionally treating all inputs as WGS84 decimal degrees.
+- **Test Fix**: Updated `test_logging_integration` to patch `debug_logging`
+  instead of `parser_service.QgsMessageLog`, matching the new logging
+  architecture.
 
 ### Changed
 
--
+- **Import Cleanup**: Removed unused imports from zoomToLatLon.py (QgsJsonUtils,
+  QgsPointXY, QgsGeometry, QgsRectangle, utm, ups, mgrs, olc, geohash,
+  maidenhead, georef, h3, parseDMSString) and removed the BUILD timestamp
+  marker.
 
 ## [3.14.2] - 2026-03-18
 

--- a/tests/integration/test_service_layer_integration.py
+++ b/tests/integration/test_service_layer_integration.py
@@ -13,96 +13,118 @@ import unittest
 from unittest.mock import Mock, patch, MagicMock
 
 # Add project root to path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
 
 class TestServiceLayerIntegration(unittest.TestCase):
     """Integration tests for the parser service layer"""
-    
+
     def setUp(self):
         """Set up test fixtures"""
         # Mock QGIS components to avoid dependency
         self.mock_settings = Mock()
         self.mock_iface = Mock()
-        
+
     def test_parser_service_import(self):
         """Test that parser service imports correctly"""
         try:
-            from parser_service import CoordinateParserService, CoordinateParserMixin, parse_coordinate_with_service
+            from parser_service import (
+                CoordinateParserService,
+                CoordinateParserMixin,
+                parse_coordinate_with_service,
+            )
+
             self.assertTrue(True, "Parser service imports successfully")
         except ImportError as e:
             self.fail(f"Parser service import failed: {e}")
-    
+
     def test_singleton_pattern(self):
         """Test that CoordinateParserService implements singleton pattern correctly"""
         from parser_service import CoordinateParserService
-        
+
         # Reset singleton for clean test
         CoordinateParserService.reset_instance()
-        
+
         # First call should create instance
-        service1 = CoordinateParserService.get_instance(self.mock_settings, self.mock_iface)
+        service1 = CoordinateParserService.get_instance(
+            self.mock_settings, self.mock_iface
+        )
         self.assertIsNotNone(service1)
-        
+
         # Second call should return same instance
         service2 = CoordinateParserService.get_instance()
-        self.assertIs(service1, service2, "Singleton pattern should return same instance")
-        
+        self.assertIs(
+            service1, service2, "Singleton pattern should return same instance"
+        )
+
         # Reset for cleanup
         CoordinateParserService.reset_instance()
-    
+
     def test_service_layer_coordination(self):
         """Test that service layer properly coordinates with optimized parser"""
-        from parser_service import parse_coordinate_with_service, CoordinateParserService
-        
+        from parser_service import (
+            parse_coordinate_with_service,
+            CoordinateParserService,
+        )
+
         # Reset singleton for clean test
         CoordinateParserService.reset_instance()
-        
+
         # Test coordinate that should be parsed by optimized parser
         test_coordinate = "POINT(1.5 2.5)"
-        
-        with patch('parser_service.OptimizedCoordinateParser') as mock_optimizer_class:
+
+        with patch("parser_service.OptimizedCoordinateParser") as mock_optimizer_class:
             # Mock OptimizedCoordinateParser to return expected result
             mock_optimizer_instance = Mock()
             mock_optimizer_instance.parse.return_value = (2.5, 1.5, None, Mock())
             mock_optimizer_class.return_value = mock_optimizer_instance
-            
+
             # Also mock the lazy loader for the smart parser
-            with patch('parser_service.LazyClassLoader') as mock_loader_class:
+            with patch("parser_service.LazyClassLoader") as mock_loader_class:
                 mock_loader = Mock()
                 mock_smart_parser = Mock()
                 mock_loader.get_instance.return_value = mock_smart_parser
                 mock_loader.is_loaded.return_value = False
                 mock_loader_class.return_value = mock_loader
-                
+
                 result = parse_coordinate_with_service(
-                    test_coordinate, "TestComponent", self.mock_settings, self.mock_iface
+                    test_coordinate,
+                    "TestComponent",
+                    self.mock_settings,
+                    self.mock_iface,
                 )
-                
+
                 # Verify service layer used optimized parser
-                self.assertTrue(mock_optimizer_class.called, "OptimizedCoordinateParser should be instantiated")
+                self.assertTrue(
+                    mock_optimizer_class.called,
+                    "OptimizedCoordinateParser should be instantiated",
+                )
                 mock_optimizer_instance.parse.assert_called_once_with(test_coordinate)
-                
+
                 # Verify result
                 self.assertIsNotNone(result)
                 lat, lon, bounds, source_crs = result
                 self.assertEqual(lat, 2.5)
                 self.assertEqual(lon, 1.5)
-        
+
         # Reset singleton after test
         CoordinateParserService.reset_instance()
-    
+
     def test_fallback_mechanism(self):
         """Test that fallback mechanism works when smart parser fails"""
         from parser_service import parse_coordinate_with_service
-        
+
         test_coordinate = "45.123, -122.456"
-        
+
         def mock_fallback(text):
             # Return result in expected format (lat, lon, bounds, crs)
             from qgis.core import QgsCoordinateReferenceSystem
+
             return (45.123, -122.456, None, QgsCoordinateReferenceSystem())
-        
-        with patch('parser_service.LazyClassLoader') as mock_loader_class:
+
+        with patch("parser_service.LazyClassLoader") as mock_loader_class:
             # Mock lazy class loader to return parser that fails
             mock_loader = Mock()
             mock_parser_instance = Mock()
@@ -110,11 +132,15 @@ class TestServiceLayerIntegration(unittest.TestCase):
             mock_loader.get_instance.return_value = mock_parser_instance
             mock_loader.is_loaded.return_value = False
             mock_loader_class.return_value = mock_loader
-            
+
             result = parse_coordinate_with_service(
-                test_coordinate, "TestComponent", self.mock_settings, self.mock_iface, mock_fallback
+                test_coordinate,
+                "TestComponent",
+                self.mock_settings,
+                self.mock_iface,
+                mock_fallback,
             )
-            
+
             # Verify fallback was used and result structure is correct
             self.assertIsNotNone(result)
             self.assertEqual(len(result), 4, "Result should be 4-tuple")
@@ -122,16 +148,19 @@ class TestServiceLayerIntegration(unittest.TestCase):
             self.assertEqual(lat, 45.123)
             self.assertEqual(lon, -122.456)
             self.assertIsNone(bounds)
-    
+
     def test_logging_integration(self):
         """Test that service layer provides consistent logging"""
         from parser_service import parse_coordinate_with_service
-        
+
         test_coordinate = "POINT(0 0)"
-        
-        with patch('parser_service.LazyClassLoader') as mock_loader_class, \
-             patch('parser_service.QgsMessageLog') as mock_log:
-            
+
+        # Patch log_debug at the module level so that the 'from .debug_logging
+        # import log_debug' inside parse_coordinate_with_logging picks up the mock.
+        with (
+            patch("parser_service.LazyClassLoader") as mock_loader_class,
+            patch("debug_logging.log_debug") as mock_log_debug,
+        ):
             # Mock lazy class loader success
             mock_loader = Mock()
             mock_parser_instance = Mock()
@@ -139,26 +168,30 @@ class TestServiceLayerIntegration(unittest.TestCase):
             mock_loader.get_instance.return_value = mock_parser_instance
             mock_loader.is_loaded.return_value = False
             mock_loader_class.return_value = mock_loader
-            
+
             parse_coordinate_with_service(
                 test_coordinate, "TestComponent", self.mock_settings, self.mock_iface
             )
-            
+
             # Verify logging was called
-            self.assertTrue(mock_log.logMessage.called)
-            
+            self.assertTrue(mock_log_debug.called)
+
             # Check that component name is in log messages
-            log_calls = mock_log.logMessage.call_args_list
-            component_mentioned = any('TestComponent' in str(call) for call in log_calls)
-            self.assertTrue(component_mentioned, "Component name should be mentioned in logs")
-    
+            log_calls = mock_log_debug.call_args_list
+            component_mentioned = any(
+                "TestComponent" in str(call) for call in log_calls
+            )
+            self.assertTrue(
+                component_mentioned, "Component name should be mentioned in logs"
+            )
+
     def test_error_handling(self):
         """Test that service layer handles errors gracefully"""
         from parser_service import parse_coordinate_with_service
-        
+
         test_coordinate = "invalid coordinate"
-        
-        with patch('parser_service.LazyClassLoader') as mock_loader_class:
+
+        with patch("parser_service.LazyClassLoader") as mock_loader_class:
             # Mock lazy class loader to raise exception
             mock_loader = Mock()
             mock_parser_instance = Mock()
@@ -166,161 +199,204 @@ class TestServiceLayerIntegration(unittest.TestCase):
             mock_loader.get_instance.return_value = mock_parser_instance
             mock_loader.is_loaded.return_value = False
             mock_loader_class.return_value = mock_loader
-            
+
             result = parse_coordinate_with_service(
                 test_coordinate, "TestComponent", self.mock_settings, self.mock_iface
             )
-            
+
             # Should return None on error
             self.assertIsNone(result)
 
+
 class TestUIComponentIntegration(unittest.TestCase):
     """Test that UI components properly use the service layer"""
-    
+
     def setUp(self):
         """Set up test fixtures"""
         self.mock_settings = Mock()
         self.mock_iface = Mock()
-    
+
     def test_coordinate_converter_integration(self):
         """Test that coordinateConverter uses service layer"""
         # Read the coordinate converter file
         try:
-            with open('coordinateConverter.py', 'r') as f:
+            with open("coordinateConverter.py", "r") as f:
                 content = f.read()
-            
+
             # Check for service layer usage
-            self.assertIn('parse_coordinate_with_service', content, 
-                         "coordinateConverter should use parse_coordinate_with_service")
-            self.assertIn('from .parser_service import', content,
-                         "coordinateConverter should import parser service")
-            
+            self.assertIn(
+                "parse_coordinate_with_service",
+                content,
+                "coordinateConverter should use parse_coordinate_with_service",
+            )
+            self.assertIn(
+                "from .parser_service import",
+                content,
+                "coordinateConverter should import parser service",
+            )
+
         except FileNotFoundError:
             self.skipTest("coordinateConverter.py not found")
-    
+
     def test_digitizer_integration(self):
         """Test that digitizer uses service layer"""
         try:
-            with open('digitizer.py', 'r') as f:
+            with open("digitizer.py", "r") as f:
                 content = f.read()
-            
+
             # Check for service layer usage
-            self.assertIn('parse_coordinate_with_service', content, 
-                         "digitizer should use parse_coordinate_with_service")
-            self.assertIn('from .parser_service import', content,
-                         "digitizer should import parser service")
-            
+            self.assertIn(
+                "parse_coordinate_with_service",
+                content,
+                "digitizer should use parse_coordinate_with_service",
+            )
+            self.assertIn(
+                "from .parser_service import",
+                content,
+                "digitizer should import parser service",
+            )
+
         except FileNotFoundError:
             self.skipTest("digitizer.py not found")
-    
+
     def test_zoomToLatLon_integration(self):
         """Test that zoomToLatLon uses service layer"""
         try:
-            with open('zoomToLatLon.py', 'r') as f:
+            with open("zoomToLatLon.py", "r") as f:
                 content = f.read()
-            
+
             # Check for service layer usage
-            self.assertIn('parse_coordinate_with_service', content, 
-                         "zoomToLatLon should use parse_coordinate_with_service")
-            self.assertIn('from .parser_service import', content,
-                         "zoomToLatLon should import parser service")
-            
+            self.assertIn(
+                "parse_coordinate_with_service",
+                content,
+                "zoomToLatLon should use parse_coordinate_with_service",
+            )
+            self.assertIn(
+                "from .parser_service import",
+                content,
+                "zoomToLatLon should import parser service",
+            )
+
         except FileNotFoundError:
             self.skipTest("zoomToLatLon.py not found")
-    
+
     def test_multizoom_integration(self):
         """Test that multizoom uses service layer"""
         try:
-            with open('multizoom.py', 'r') as f:
+            with open("multizoom.py", "r") as f:
                 content = f.read()
-            
+
             # Check for service layer usage
-            self.assertIn('parse_coordinate_with_service', content, 
-                         "multizoom should use parse_coordinate_with_service")
-            self.assertIn('from .parser_service import', content,
-                         "multizoom should import parser service")
-            
+            self.assertIn(
+                "parse_coordinate_with_service",
+                content,
+                "multizoom should use parse_coordinate_with_service",
+            )
+            self.assertIn(
+                "from .parser_service import",
+                content,
+                "multizoom should import parser service",
+            )
+
         except FileNotFoundError:
             self.skipTest("multizoom.py not found")
 
+
 class TestServiceLayerCompatibility(unittest.TestCase):
     """Test that service layer maintains compatibility with existing functionality"""
-    
+
     def test_coordinates_still_parse(self):
         """Test that various coordinate formats still parse through service layer"""
-        from parser_service import parse_coordinate_with_service, CoordinateParserService
-        
+        from parser_service import (
+            parse_coordinate_with_service,
+            CoordinateParserService,
+        )
+
         # Reset singleton for clean test
         CoordinateParserService.reset_instance()
-        
+
         mock_settings = Mock()
         mock_iface = Mock()
-        
+
         # Test simple decimal coordinates (most reliable for testing)
         test_cases = [
             ("45.123, -122.456", "Basic lat/lon"),
             ("1.5, 2.5", "Simple decimal"),  # Simpler than WKT for testing
         ]
-        
+
         for test_input, description in test_cases:
             with self.subTest(coordinate=test_input):
                 result = parse_coordinate_with_service(
                     test_input, "Test", mock_settings, mock_iface
                 )
-                
+
                 # Since we're using real parsing, just check that we get a valid result
                 # The result should be a 4-tuple (lat, lon, bounds, crs) or None
                 if result is not None:
-                    self.assertEqual(len(result), 4, f"Result should be 4-tuple for {description}")
+                    self.assertEqual(
+                        len(result), 4, f"Result should be 4-tuple for {description}"
+                    )
                     lat, lon, bounds, crs = result
-                    self.assertIsInstance(lat, (int, float), f"Latitude should be numeric for {description}")
-                    self.assertIsInstance(lon, (int, float), f"Longitude should be numeric for {description}")
+                    self.assertIsInstance(
+                        lat,
+                        (int, float),
+                        f"Latitude should be numeric for {description}",
+                    )
+                    self.assertIsInstance(
+                        lon,
+                        (int, float),
+                        f"Longitude should be numeric for {description}",
+                    )
                 else:
                     # If parsing fails, that's okay for this test - we're just checking the service layer works
-                    self.skipTest(f"Parsing failed for {test_input} - this is acceptable in test environment")
-        
+                    self.skipTest(
+                        f"Parsing failed for {test_input} - this is acceptable in test environment"
+                    )
+
         # Reset singleton after test
         CoordinateParserService.reset_instance()
+
 
 def run_service_layer_tests():
     """Run all service layer tests"""
     print("🔧 RUNNING SERVICE LAYER INTEGRATION TESTS")
     print("=" * 50)
-    
+
     # Create test suite
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
-    
+
     # Add test classes
     suite.addTests(loader.loadTestsFromTestCase(TestServiceLayerIntegration))
     suite.addTests(loader.loadTestsFromTestCase(TestUIComponentIntegration))
     suite.addTests(loader.loadTestsFromTestCase(TestServiceLayerCompatibility))
-    
+
     # Run tests
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)
-    
-    print(f"\n📊 SERVICE LAYER TEST SUMMARY:")
+
+    print("\n📊 SERVICE LAYER TEST SUMMARY:")
     print(f"Tests run: {result.testsRun}")
     print(f"Failures: {len(result.failures)}")
     print(f"Errors: {len(result.errors)}")
-    
+
     if result.wasSuccessful():
         print("🎉 ALL SERVICE LAYER TESTS PASSED!")
     else:
         print("⚠️ SOME SERVICE LAYER TESTS FAILED!")
-        
+
         if result.failures:
             print("\nFAILURES:")
             for test, traceback in result.failures:
                 print(f"- {test}")
-        
+
         if result.errors:
             print("\nERRORS:")
             for test, traceback in result.errors:
                 print(f"- {test}")
-    
+
     return result.wasSuccessful()
+
 
 if __name__ == "__main__":
     success = run_service_layer_tests()

--- a/zoomToLatLon.py
+++ b/zoomToLatLon.py
@@ -11,8 +11,6 @@
  ***************************************************************************/
 """
 
-# BUILD: 2026-03-17-08:30-ULTRAFAST
-
 import os
 import re
 import traceback
@@ -23,37 +21,19 @@ from qgis.PyQt.QtWidgets import QDockWidget, QApplication, QMenu
 from qgis.gui import QgsRubberBand, QgsProjectionSelectionDialog
 from qgis.core import (
     Qgis,
-    QgsJsonUtils,
     QgsWkbTypes,
-    QgsPointXY,
-    QgsGeometry,
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
     QgsProject,
-    QgsRectangle,
     QgsMessageLog,
 )
-from .util import epsg4326, parseDMSString, tr
+from .util import epsg4326, tr
 from .settings import settings, CoordOrder, H3_INSTALLED
-from .utm import isUtm, utm2Point
-from .ups import isUps, ups2Point
-from . import mgrs
-from . import olc
-from . import geohash
-from .maidenhead import maidenGrid
-from . import georef
 from .parser_service import parse_coordinate_with_service
-
-if H3_INSTALLED:
-    import h3
 
 # Pre-compile regex patterns for performance
 COMPILED_REGEX = {
-    "whitespace": re.compile(r"\s+"),
-    "point_search": re.compile(r"POINT\("),
-    "point_extract": re.compile(r"POINT\(\s*([+-]?\d*\.?\d*)\s+([+-]?\d*\.?\d*)"),
     "coord_split": re.compile(r"[\s,;:]+"),
-    "mgrs_clean": re.compile(r"\s+"),
     # Ultra-fast path for simple decimal degrees (most common case)
     "simple_decimal": re.compile(
         r"^\s*([+-]?\d+\.?\d*)\s*[\s,;:]+\s*([+-]?\d+\.?\d*)\s*$"
@@ -187,39 +167,83 @@ class ZoomToLatLon(QDockWidget, FORM_CLASS):
             self.xyButton.setIcon(self.xyIcon)
 
     def convertCoordinate(self, text):
-        """Parse coordinate text with ultra-fast path for simple decimal degrees."""
-        from .debug_logging import log_debug, log_error
+        """Parse coordinate text based on the current CRS mode.
 
+        - WGS84 mode: ultra-fast decimal path, then smart parser
+        - Project/Custom CRS mode: try projected coordinates, then smart parser
+        - Forced formats (MGRS, UTM, etc.): delegate to smart parser
+        - Smart Auto-Detect and other modes: delegate to smart parser
+        """
         text = text.strip() if text else ""
 
-        # ========== ULTRA-FAST PATH: Simple decimal degrees ==========
-        # Handles 90%+ of common coordinate inputs with a single regex match
-        m = COMPILED_REGEX["simple_decimal"].match(text)
-        if m:
-            try:
-                val1 = float(m.group(1))
-                val2 = float(m.group(2))
+        # ========== WGS84 ULTRA-FAST PATH ==========
+        # zoomToProjIsWgs84() returns True for: WGS84 mode, ProjectCRS when
+        # project CRS is EPSG:4326, and CustomCRS when custom CRS is EPSG:4326.
+        if self.settings.zoomToProjIsWgs84():
+            m = COMPILED_REGEX["simple_decimal"].match(text)
+            if m:
+                try:
+                    val1 = float(m.group(1))
+                    val2 = float(m.group(2))
 
-                # Apply coordinate order preference
+                    if self.settings.zoomToCoordOrder == CoordOrder.OrderYX:
+                        lat, lon = val1, val2  # Input is "lat, lon"
+                    else:
+                        lat, lon = val2, val1  # Input is "lon, lat"
+
+                    if -90 <= lat <= 90 and -180 <= lon <= 180:
+                        return (lat, lon, None, epsg4326)
+
+                    # Try swapped if original order failed validation
+                    if -90 <= lon <= 90 and -180 <= lat <= 180:
+                        return (lon, lat, None, epsg4326)
+
+                except (ValueError, TypeError):
+                    pass  # Fall through to smart parser
+            return self._parseWithSmartParser(text)
+
+        # ========== NON-WGS84 PATH ==========
+        # Check for forced formats — delegate directly to smart parser
+        if (
+            self.settings.zoomToProjIsMGRS()
+            or self.settings.zoomToProjIsPlusCodes()
+            or self.settings.zoomToProjIsStandardUtm()
+            or self.settings.zoomToProjIsGeohash()
+            or self.settings.zoomToProjIsH3()
+            or self.settings.zoomToProjIsMaidenhead()
+        ):
+            return self._parseWithSmartParser(text)
+
+        # ========== PROJECTED CRS PATH ==========
+        # Project CRS or Custom CRS mode (non-EPSG:4326): try parsing as two
+        # projected numbers. Falls through to smart parser on failure.
+        try:
+            coords = COMPILED_REGEX["coord_split"].split(text, 1)
+            if (
+                len(coords) >= 2
+                and self.is_number(coords[0])
+                and self.is_number(coords[1])
+            ):
                 if self.settings.zoomToCoordOrder == CoordOrder.OrderYX:
-                    lat, lon = val1, val2  # Input is "lat, lon"
+                    lat, lon = float(coords[0]), float(coords[1])
                 else:
-                    lat, lon = val2, val1  # Input is "lon, lat"
+                    lon, lat = float(coords[0]), float(coords[1])
+                if self.settings.zoomToProjIsProjectCRS():
+                    srcCrs = self.canvas.mapSettings().destinationCrs()
+                else:
+                    srcCrs = self.settings.zoomToCustomCRS()
+                return (lat, lon, None, srcCrs)
+        except (ValueError, TypeError):
+            pass
 
-                # Validate geographic ranges
-                if -90 <= lat <= 90 and -180 <= lon <= 180:
-                    return (lat, lon, None, epsg4326)
+        # Fall through to smart parser for non-numeric input (WKT, DMS, etc.)
+        # or unrecognized modes (Smart Auto-Detect, UPS, GEOREF, etc.)
+        return self._parseWithSmartParser(text)
 
-                # Try swapped if original order failed validation
-                if -90 <= lon <= 90 and -180 <= lat <= 180:
-                    return (lon, lat, None, epsg4326)
+    def _parseWithSmartParser(self, text):
+        """Delegate parsing to the smart parser service."""
+        from .debug_logging import log_debug, log_error
 
-            except (ValueError, TypeError):
-                pass  # Fall through to smart parser
-
-        # ========== SMART PARSER PATH: All other formats ==========
-        # The smart parser handles: WKT, GeoJSON, MGRS, UTM, UPS, Plus Codes,
-        # Geohash, H3, Maidenhead, GEOREF, DMS, and more
         log_debug("Using smart parser for complex format")
         try:
             result = parse_coordinate_with_service(
@@ -237,7 +261,7 @@ class ZoomToLatLon(QDockWidget, FORM_CLASS):
 
         try:
             text = self.coordTxt.text().strip()
-            log_info(f"[v3.14.1] zoomToPressed: '{text}'")
+            log_info(f"zoomToPressed: '{text}'")
 
             result = self.convertCoordinate(text)
             if result is None:
@@ -254,8 +278,6 @@ class ZoomToLatLon(QDockWidget, FORM_CLASS):
             if srcCrs is None or not (hasattr(srcCrs, "isValid") and srcCrs.isValid()):
                 log_warning(f"Invalid CRS: {srcCrs}, assuming WGS84")
                 try:
-                    from qgis.core import QgsCoordinateReferenceSystem
-
                     srcCrs = QgsCoordinateReferenceSystem("EPSG:4326")
                     if not srcCrs.isValid():
                         srcCrs = None
@@ -298,8 +320,6 @@ class ZoomToLatLon(QDockWidget, FORM_CLASS):
                 "LatLonTools",
                 Qgis.Critical,
             )
-            import traceback
-
             QgsMessageLog.logMessage(
                 f"ZoomToLatLon.zoomToPressed: Traceback: {traceback.format_exc()}",
                 "LatLonTools",

--- a/zoomToLatLon.py
+++ b/zoomToLatLon.py
@@ -215,26 +215,33 @@ class ZoomToLatLon(QDockWidget, FORM_CLASS):
             return self._parseWithSmartParser(text)
 
         # ========== PROJECTED CRS PATH ==========
-        # Project CRS or Custom CRS mode (non-EPSG:4326): try parsing as two
-        # projected numbers. Falls through to smart parser on failure.
-        try:
-            coords = COMPILED_REGEX["coord_split"].split(text, 1)
-            if (
-                len(coords) >= 2
-                and self.is_number(coords[0])
-                and self.is_number(coords[1])
-            ):
-                if self.settings.zoomToCoordOrder == CoordOrder.OrderYX:
-                    lat, lon = float(coords[0]), float(coords[1])
-                else:
-                    lon, lat = float(coords[0]), float(coords[1])
-                if self.settings.zoomToProjIsProjectCRS():
-                    srcCrs = self.canvas.mapSettings().destinationCrs()
-                else:
-                    srcCrs = self.settings.zoomToCustomCRS()
-                return (lat, lon, None, srcCrs)
-        except (ValueError, TypeError):
-            pass
+        # Only try projected coordinate parsing when explicitly in Project CRS
+        # or Custom CRS mode. Other modes (Smart Auto-Detect, UPS, GEOREF)
+        # fall through to the smart parser below.
+        is_projected_mode = (
+            self.settings.zoomToProjIsProjectCRS()
+            or self.settings.zoomToProjection == self.settings.ProjectionTypeCustomCRS
+        )
+
+        if is_projected_mode:
+            try:
+                coords = COMPILED_REGEX["coord_split"].split(text, 1)
+                if (
+                    len(coords) >= 2
+                    and self.is_number(coords[0])
+                    and self.is_number(coords[1])
+                ):
+                    if self.settings.zoomToCoordOrder == CoordOrder.OrderYX:
+                        lat, lon = float(coords[0]), float(coords[1])
+                    else:
+                        lon, lat = float(coords[0]), float(coords[1])
+                    if self.settings.zoomToProjIsProjectCRS():
+                        srcCrs = self.canvas.mapSettings().destinationCrs()
+                    else:
+                        srcCrs = self.settings.zoomToCustomCRS()
+                    return (lat, lon, None, srcCrs)
+            except (ValueError, TypeError):
+                pass
 
         # Fall through to smart parser for non-numeric input (WKT, DMS, etc.)
         # or unrecognized modes (Smart Auto-Detect, UPS, GEOREF, etc.)


### PR DESCRIPTION
## Summary

- **Fix projected CRS zoom**: Restored Project CRS and Custom CRS coordinate parsing in the Zoom dialog, broken in v3.14.2 when the ultra-fast path unconditionally treated all inputs as WGS84 decimal degrees
- **Handle Smart Auto-Detect mode**: Unrecognized CRS modes (Smart Auto-Detect, UPS, GEOREF) now correctly fall through to the smart parser instead of being misrouted to the projected coordinate path
- **Add projected CRS fallback**: Non-numeric input in Project/Custom CRS mode (WKT, DMS) now falls through to the smart parser instead of raising "Invalid Coordinates"
- **Fix logging test**: `test_logging_integration` now patches `debug_logging.log_debug` instead of the non-existent `debug_logging.QgsMessageLog`
- **Remove unused imports**: Cleaned up 18 unused imports (QgsJsonUtils, QgsPointXY, QgsGeometry, QgsRectangle, utm, ups, mgrs, olc, geohash, maidenhead, georef, h3, parseDMSString) and the BUILD timestamp marker

## Test plan

- [ ] Verify Project CRS mode zoom works with projected coordinates (e.g. `500000 4649776` in UTM project)
- [ ] Verify Custom CRS mode zoom works with projected coordinates
- [ ] Verify WGS84 mode still uses ultra-fast decimal path
- [ ] Verify forced formats (MGRS, UTM, Plus Codes, etc.) still work via smart parser
- [ ] Verify Smart Auto-Detect mode works via smart parser
- [ ] Run standalone tests: `python3 run_all_tests.py --type standalone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)